### PR TITLE
Hapus level progress dan perbaiki splashscreen

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -245,7 +245,7 @@
     <!-- Video Cutscene -->
     <div id="video-container">
         <video id="cutscene-video" autoplay muted>
-            <source src="/public/Video/opening.mp4" type="video/mp4">
+            <source src="public/Video/opening.mp4" type="video/mp4">
             Video tidak dapat dimuat.
         </video>
         <button id="skip-button">Skip ⏭</button>
@@ -261,11 +261,11 @@
                 
                 // Array of 5 cutscene videos
                 this.cutsceneVideos = [
-                    '/public/Video/opening.mp4',
-                    '/public/Video/ilmuwan.mp4',
-                    '/public/Video/video.mp4',
-                    '/public/Video/video action.mp4',
-                    '/public/Video/final.mp4'
+                    'public/Video/opening.mp4',
+                    'public/Video/ilmuwan.mp4',
+                    'public/Video/video.mp4',
+                    'public/Video/video action.mp4',
+                    'public/Video/final.mp4'
                 ];
                 this.currentVideoIndex = 0;
                 
@@ -276,7 +276,7 @@
                 // Start splash screen sequence
                 setTimeout(() => {
                     this.showCutscene();
-                }, 5500); // Wait for splash animations to complete
+                }, 3000); // Reduced wait time for better UX
 
                 // Skip button functionality
                 this.skipButton.addEventListener('click', () => {
@@ -293,6 +293,23 @@
                     console.log('Video failed to load, trying next video or proceeding to main menu');
                     this.playNextVideo();
                 });
+
+                // Fallback: if no videos work, go to main menu after 10 seconds
+                setTimeout(() => {
+                    if (this.videoContainer.style.display === 'block' && this.video.paused) {
+                        console.log('Fallback: No videos loaded, going to main menu');
+                        this.skipToMainMenu();
+                    }
+                }, 10000);
+
+                // Keyboard support for skipping
+                document.addEventListener('keydown', (e) => {
+                    if (e.key === 'Escape' || e.key === ' ' || e.key === 'Enter') {
+                        if (this.videoContainer.style.display === 'block') {
+                            this.skipToMainMenu();
+                        }
+                    }
+                });
             }
 
             showCutscene() {
@@ -304,17 +321,24 @@
             playCurrentVideo() {
                 if (this.currentVideoIndex < this.cutsceneVideos.length) {
                     const videoSrc = this.cutsceneVideos[this.currentVideoIndex];
+                    console.log('Loading video:', videoSrc);
                     this.video.src = videoSrc;
                     
-                    // Try to play video
-                    this.video.play().catch(error => {
-                        console.log('Video autoplay failed:', error);
-                        // If autoplay fails, try next video after short delay
-                        setTimeout(() => {
-                            this.playNextVideo();
-                        }, 2000);
-                    });
+                    // Load the video first
+                    this.video.load();
+                    
+                    // Try to play video after a short delay to ensure it's loaded
+                    setTimeout(() => {
+                        this.video.play().catch(error => {
+                            console.log('Video autoplay failed:', error);
+                            // If autoplay fails, try next video after short delay
+                            setTimeout(() => {
+                                this.playNextVideo();
+                            }, 1000);
+                        });
+                    }, 500);
                 } else {
+                    console.log('All videos played, going to main menu');
                     this.skipToMainMenu();
                 }
             }

--- a/src/main-menu.html
+++ b/src/main-menu.html
@@ -42,14 +42,6 @@
                 </div>
             </div>
             <p class="game-subtitle">🔋 Misteri Hemat Listrik ⚡</p>
-            <!-- Progress indicator -->
-            <div class="global-progress">
-                <div class="progress-text">Progress Keseluruhan</div>
-                <div class="progress-bar-global">
-                    <div class="progress-fill-global" id="global-progress-fill"></div>
-                </div>
-                <div class="progress-percentage" id="global-progress-text">0%</div>
-            </div>
         </div>
 
         <!-- Top Right Options -->
@@ -204,12 +196,8 @@
     <script src="scripts/main-menu.js"></script>
     
     <script>
-        // Enhanced Main Menu with Dynamic Progress
+        // Enhanced Main Menu
         document.addEventListener('DOMContentLoaded', function() {
-            // Simulate progress loading animation
-            setTimeout(() => {
-                updateGlobalProgress();
-            }, 1000);
             
             // Add hover effects to buttons
             const buttons = document.querySelectorAll('.unity-btn');
@@ -226,35 +214,6 @@
             });
         });
         
-        function updateGlobalProgress() {
-            const progressFill = document.getElementById('global-progress-fill');
-            const progressText = document.getElementById('global-progress-text');
-            
-            // Calculate progress based on completed levels (example)
-            let completedLevels = 0;
-            const totalLevels = 5;
-            
-            // Check localStorage for completed levels
-            if (localStorage.getItem('level1_completed')) completedLevels++;
-            if (localStorage.getItem('level2_completed')) completedLevels++;
-            if (localStorage.getItem('quiz_completed')) completedLevels++;
-            if (localStorage.getItem('experiments_completed')) completedLevels++;
-            if (localStorage.getItem('final_gate_unlocked')) completedLevels++;
-            
-            const percentage = Math.round((completedLevels / totalLevels) * 100);
-            
-            // Animate progress bar
-            setTimeout(() => {
-                progressFill.style.width = percentage + '%';
-                progressText.textContent = percentage + '%';
-            }, 500);
-            
-            // Add completion effects
-            if (percentage === 100) {
-                progressFill.style.background = 'linear-gradient(45deg, #00ff00 0%, #32cd32 100%)';
-                progressText.textContent = '🎉 SELESAI! 🎉';
-            }
-        }
         
         // Enhanced button click effects
         function addClickEffect(element) {

--- a/src/opening-animation.html
+++ b/src/opening-animation.html
@@ -350,5 +350,12 @@
     </a>
 
     <script src="public/opening-animation.js"></script>
+    <script>
+        // Function to navigate to main menu
+        function goToMainMenu() {
+            console.log('Navigating to main menu...');
+            window.location.href = 'main-menu.html';
+        }
+    </script>
 </body>
 </html>


### PR DESCRIPTION
Remove level progress from the main menu and fix the splash screen getting stuck before playing videos.

The splash screen fix addresses issues with video paths, loading sequence, and adds robust error handling with a fallback mechanism and keyboard skip support.

---
<a href="https://cursor.com/background-agent?bcId=bc-d7bb7bfb-097b-4128-9e63-7668f491a47f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d7bb7bfb-097b-4128-9e63-7668f491a47f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

